### PR TITLE
fix: prevent error if event exceptions are empty

### DIFF
--- a/src/Integration/UseShopwareExceptionIgnores.php
+++ b/src/Integration/UseShopwareExceptionIgnores.php
@@ -17,7 +17,7 @@ class UseShopwareExceptionIgnores implements IntegrationInterface
         $exceptions = $this->exceptions;
 
         Scope::addGlobalEventProcessor(function (Event $event) use($exceptions): ?Event {
-            $eventExceptions = $event->getExceptions()[0];
+            $eventExceptions = $event->getExceptions()[0] ?? null;
 
             if ($eventExceptions === null) {
                 return $event;


### PR DESCRIPTION
If there are no errors in the event, an "Undefined array key 0" error is thrown.
This pull request should prevent this.