### PR TITLE
Support flow event log

### DIFF
--- a/src/Exception/FlowEventException.php
+++ b/src/Exception/FlowEventException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\SentryBundle\Exception;
+
+use Monolog\Level;
+use Throwable;
+
+class FlowEventException extends \Exception
+{
+    public function __construct(readonly string $eventName = '', ?Level $level = null, ?Throwable $previous = null, readonly mixed $context = null)
+    {
+        $message = sprintf('Flow event %s level %s occurred', $this->eventName, $level?->toPsrLogLevel() ?? 'unknown');
+        parent::__construct($message, $level?->value ?? 0, $previous);
+    }
+
+}

--- a/src/ShopwareSentryBundle.php
+++ b/src/ShopwareSentryBundle.php
@@ -7,6 +7,7 @@ use Frosh\SentryBundle\Instrumentation\SentryProfiler;
 use Frosh\SentryBundle\Integration\UseShopwareExceptionIgnores;
 use Frosh\SentryBundle\Listener\FixRequestUrlListener;
 use Frosh\SentryBundle\Listener\SalesChannelContextListener;
+use Frosh\SentryBundle\Subscriber\FlowLogSubscriber;
 use Frosh\SentryBundle\Subscriber\ScheduledTaskSubscriber;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -42,6 +43,10 @@ class ShopwareSentryBundle extends Bundle
             ->register(ScheduledTaskSubscriber::class)
             ->addArgument(new Reference('scheduled_task.repository'))
             ->addArgument('%frosh_sentry.report_scheduled_tasks%')
+            ->addTag('kernel.event_subscriber');
+
+        $container
+            ->register(FlowLogSubscriber::class)
             ->addTag('kernel.event_subscriber');
 
         $container->addCompilerPass(new CompilerPass\ExceptionConfigCompilerPass());

--- a/src/Subscriber/FlowLogSubscriber.php
+++ b/src/Subscriber/FlowLogSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\SentryBundle\Subscriber;
+
+use Frosh\SentryBundle\Exception\FlowEventException;
+use Monolog\Level;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Event\FlowLogEvent;
+use Shopware\Core\Framework\Log\LogAware;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function Sentry\captureException;
+
+class FlowLogSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [FlowLogEvent::NAME => 'sendFlowEvent'];
+    }
+
+    public function sendFlowEvent(FlowLogEvent $event): void
+    {
+        $innerEvent = $event->getEvent();
+
+        $additionalData = [];
+        $logLevel = Level::Debug;
+
+        if ($innerEvent instanceof LogAware) {
+            $logLevel = $innerEvent->getLogLevel();
+            $additionalData = $innerEvent->getLogData();
+        }
+
+        if ($logLevel->isLowerThan(Level::Warning)) {
+            return;
+        }
+
+        $nestedException = null;
+        if (method_exists($innerEvent, 'getThrowable')) {
+            $nestedException = $innerEvent->getThrowable();
+        }
+
+        captureException(new FlowEventException($innerEvent->getName(), $logLevel, $nestedException, $additionalData));
+    }
+
+}

--- a/src/Subscriber/ScheduledTaskSubscriber.php
+++ b/src/Subscriber/ScheduledTaskSubscriber.php
@@ -103,7 +103,7 @@ class ScheduledTaskSubscriber implements EventSubscriberInterface
 
     private function captureCheckIn(ScheduledTaskEntity $scheduledTask, CheckInStatus $status): void
     {
-        if($status === CheckInStatus::inProgress()) {
+        if ($status === CheckInStatus::inProgress()) {
             $scheduledTask->removeExtension('sentryCheckInId');
             $checkInId = $this->getCheckInId($scheduledTask);
             $scheduledTask->addArrayExtension('sentryCheckInId', [$checkInId]);
@@ -116,7 +116,7 @@ class ScheduledTaskSubscriber implements EventSubscriberInterface
     private function getCheckInId(ScheduledTaskEntity $scheduledTask): ?string
     {
         $extension = $scheduledTask->getExtension('sentryCheckInId');
-        if($extension instanceof ArrayStruct) {
+        if ($extension instanceof ArrayStruct) {
             return \is_string($extension->get(0)) ? $extension->get(0) : null;
         }
 


### PR DESCRIPTION
Flow event log entries are sent to sentry.

Closes #8