### PR TITLE
Update composer dependencies for shopware 6.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "sentry/sentry-symfony": "^4.0 || ^5.0",
-        "shopware/core": "~6.5.0 || ~6.6.0"
+        "shopware/core": "~6.5.0 || ~6.6.0 || ~6.7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello!

This pull request updates the compatibility constraints to allow installation of the bundle with Shopware 6.7 and above.

I’ve successfully installed and tested it with the Release Candidate 4 of Shopware 6.7.