### PR TITLE
Use a type-compatible method for accessing data.

### DIFF
--- a/src/Subscriber/ScheduledTaskSubscriber.php
+++ b/src/Subscriber/ScheduledTaskSubscriber.php
@@ -117,7 +117,7 @@ class ScheduledTaskSubscriber implements EventSubscriberInterface
     {
         $extension = $scheduledTask->getExtension('sentryCheckInId');
         if ($extension instanceof ArrayStruct) {
-            return \is_string($extension->get(0)) ? $extension->get(0) : null;
+            return \is_string($extension->offsetGet(0)) ? $extension->offsetGet(0) : null;
         }
 
         return captureCheckIn(


### PR DESCRIPTION
Also found by using PhpStorm's code inspection: \Shopware\Core\Framework\Struct\ArrayStruct::get() expects the argument to be a string, so – as the first element is to be fetched – it might be better to use \Shopware\Core\Framework\Struct\ArrayStruct::offsetSet().