### PR TITLE
Declare compatibility with Shopware 6.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "sentry/sentry-symfony": "^4.0 || ^5.0",
-        "shopware/core": "~6.5.0 || ~6.6.0"
+        "shopware/core": "~6.4.0 || ~6.5.0 || ~6.6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I changed this locally and found no problems when using the bundle with Shopware 6.4.20.2, so – although that Shopware version is pretty old – the compatibility could be added as a help for older projects.