### PR TITLE
Remove unused import from unknown namespace.

### DIFF
--- a/src/Subscriber/ScheduledTaskSubscriber.php
+++ b/src/Subscriber/ScheduledTaskSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Frosh\SentryBundle\Subscriber;
 
-use MbCore\Component\Gallery\Entity\GalleryDefinition;
 use Sentry\MonitorConfig;
 use Sentry\MonitorScheduleUnit;
 use Shopware\Core\Framework\Api\Context\SystemSource;


### PR DESCRIPTION
When using PhpStorm's code inspection, this import (which is never used) was reported; in my opinion it should be removed.